### PR TITLE
KLCH-182 - Pin kombu to 4.6.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,8 @@ async = [
 ]
 celery = [
     'celery>=3.1.17',
-    'flower>=0.7.3'
+    'flower>=0.7.3',
+    'kombu==4.6.3'
 ]
 cgroups = [
     'cgroupspy>=0.1.4',


### PR DESCRIPTION
Cherry picked from: https://github.com/apache/airflow/commit/3c25166f9f48a854fa91cf5852a6571277ad7006

I also incremented the version branch to msh_1.8.1.3 (but I haven't tested any of this. @dturet I wanted your thoughts on the best way to test this. I'm not even convinced that this setup.py script is running as part of the boot-up of our instannce)